### PR TITLE
Update repo urls for circleci megalinter orb

### DIFF
--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -61,7 +61,7 @@ import { Aside, Card, CardGrid, LinkButton, LinkCard, Icon } from "@astrojs/star
   />
   <LinkCard
     title="CircleCI Megalinter Orb"
-    href="https://github.com/RelativeSure/circleci-megalinter-orb"
+    href="https://github.com/KubeArchitect/circleci-megalinter-orb"
     description="A CircleCI Megalinter orb to be used to lint files and/or directories."
   />
   <LinkCard

--- a/src/content/docs/projects/work-in-progress.mdx
+++ b/src/content/docs/projects/work-in-progress.mdx
@@ -19,7 +19,7 @@ import { LinkCard, CardGrid } from "@astrojs/starlight/components";
   />
   <LinkCard
     title="CircleCI Megalinter Orb"
-    href="https://github.com/RelativeSure/circleci-megalinter-orb"
+    href="https://github.com/KubeArchitect/circleci-megalinter-orb"
     description="CircleCI public orb to use Megalinter in CircleCI workflows."
   />
 </CardGrid>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the hyperlink for the CircleCI Megalinter Orb, redirecting users to the repository's new location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->