### PR TITLE
Fix: Remove 'new' badges from sidebar items

### DIFF
--- a/src/content/docs/goodstuff/git.mdx
+++ b/src/content/docs/goodstuff/git.mdx
@@ -1,7 +1,6 @@
 ---
 title: Git
 description: Good Stuff for Git
-sidebar:
 ---
 
 import { Code } from '@astrojs/starlight/components'

--- a/src/content/docs/goodstuff/git.mdx
+++ b/src/content/docs/goodstuff/git.mdx
@@ -2,7 +2,6 @@
 title: Git
 description: Good Stuff for Git
 sidebar:
-  badge: new
 ---
 
 import { Code } from '@astrojs/starlight/components'

--- a/src/content/docs/goodstuff/helm.mdx
+++ b/src/content/docs/goodstuff/helm.mdx
@@ -2,7 +2,6 @@
 title: Helm
 description: Good Stuff for Helm
 sidebar:
-  badge: new
 ---
 
 import { Code, LinkCard } from '@astrojs/starlight/components';

--- a/src/content/docs/goodstuff/helm.mdx
+++ b/src/content/docs/goodstuff/helm.mdx
@@ -1,7 +1,6 @@
 ---
 title: Helm
 description: Good Stuff for Helm
-sidebar:
 ---
 
 import { Code, LinkCard } from '@astrojs/starlight/components';

--- a/src/content/docs/goodstuff/nodejs.mdx
+++ b/src/content/docs/goodstuff/nodejs.mdx
@@ -1,7 +1,6 @@
 ---
 title: NodeJS
 sidebar:
-  badge: new
 ---
 
 import { Code } from '@astrojs/starlight/components';

--- a/src/content/docs/goodstuff/nodejs.mdx
+++ b/src/content/docs/goodstuff/nodejs.mdx
@@ -1,6 +1,5 @@
 ---
 title: NodeJS
-sidebar:
 ---
 
 import { Code } from '@astrojs/starlight/components';

--- a/src/content/docs/goodstuff/vscode.mdx
+++ b/src/content/docs/goodstuff/vscode.mdx
@@ -1,6 +1,5 @@
 ---
 title: VSCode
-sidebar:
 ---
 
 import { Code } from '@astrojs/starlight/components'

--- a/src/content/docs/goodstuff/vscode.mdx
+++ b/src/content/docs/goodstuff/vscode.mdx
@@ -1,7 +1,6 @@
 ---
 title: VSCode
 sidebar:
-  badge: new
 ---
 
 import { Code } from '@astrojs/starlight/components'

--- a/src/content/docs/linux/aliases.mdx
+++ b/src/content/docs/linux/aliases.mdx
@@ -1,7 +1,6 @@
 ---
 title: Aliases
 description: Aliases to use on Linux
-sidebar:
 ---
 
 import { Code } from '@astrojs/starlight/components'

--- a/src/content/docs/linux/aliases.mdx
+++ b/src/content/docs/linux/aliases.mdx
@@ -2,7 +2,6 @@
 title: Aliases
 description: Aliases to use on Linux
 sidebar:
-  badge: new
 ---
 
 import { Code } from '@astrojs/starlight/components'

--- a/src/content/docs/linux/fish.mdx
+++ b/src/content/docs/linux/fish.mdx
@@ -1,7 +1,6 @@
 ---
 title: Fish Shell
 sidebar:
-  badge: new
 ---
 
 import { LinkCard } from '@astrojs/starlight/components';

--- a/src/content/docs/linux/fish.mdx
+++ b/src/content/docs/linux/fish.mdx
@@ -1,6 +1,5 @@
 ---
 title: Fish Shell
-sidebar:
 ---
 
 import { LinkCard } from '@astrojs/starlight/components';

--- a/src/content/docs/linux/lvm.mdx
+++ b/src/content/docs/linux/lvm.mdx
@@ -1,7 +1,6 @@
 ---
 title: Logical Volume Manager
 sidebar:
-  badge: new
 ---
 
 import { Steps } from "@astrojs/starlight/components";

--- a/src/content/docs/linux/lvm.mdx
+++ b/src/content/docs/linux/lvm.mdx
@@ -1,6 +1,5 @@
 ---
 title: Logical Volume Manager
-sidebar:
 ---
 
 import { Steps } from "@astrojs/starlight/components";

--- a/src/content/docs/linux/requirements.mdx
+++ b/src/content/docs/linux/requirements.mdx
@@ -1,7 +1,6 @@
 ---
 title: Requirements
 description: These are the requirements for the Linux section
-sidebar:
 ---
 
 import { CardGrid, LinkCard } from '@astrojs/starlight/components'

--- a/src/content/docs/linux/requirements.mdx
+++ b/src/content/docs/linux/requirements.mdx
@@ -2,7 +2,6 @@
 title: Requirements
 description: These are the requirements for the Linux section
 sidebar:
-  badge: new
 ---
 
 import { CardGrid, LinkCard } from '@astrojs/starlight/components'

--- a/src/content/docs/linux/sources.mdx
+++ b/src/content/docs/linux/sources.mdx
@@ -2,7 +2,6 @@
 title: Sites
 description: Sites for linux
 sidebar:
-  badge: new
 ---
 
 ## TLDR

--- a/src/content/docs/linux/sources.mdx
+++ b/src/content/docs/linux/sources.mdx
@@ -1,7 +1,6 @@
 ---
 title: Sites
 description: Sites for linux
-sidebar:
 ---
 
 ## TLDR

--- a/src/content/docs/linux/ubuntu.mdx
+++ b/src/content/docs/linux/ubuntu.mdx
@@ -1,7 +1,6 @@
 ---
 title: Ubuntu
 sidebar:
-  badge: new
 ---
 
 ## Root access via nonroot

--- a/src/content/docs/linux/ubuntu.mdx
+++ b/src/content/docs/linux/ubuntu.mdx
@@ -1,6 +1,5 @@
 ---
 title: Ubuntu
-sidebar:
 ---
 
 ## Root access via nonroot

--- a/src/content/docs/website/website.mdx
+++ b/src/content/docs/website/website.mdx
@@ -1,6 +1,5 @@
 ---
 title: Website setup
-sidebar:
 ---
 
 This page is primarily for use on how I setup different parts of my website. It is a work in progress and will be updated as I make changes to my website.

--- a/src/content/docs/website/website.mdx
+++ b/src/content/docs/website/website.mdx
@@ -1,7 +1,6 @@
 ---
 title: Website setup
 sidebar:
-  badge: new
 ---
 
 This page is primarily for use on how I setup different parts of my website. It is a work in progress and will be updated as I make changes to my website.

--- a/src/content/docs/windows/powershell.mdx
+++ b/src/content/docs/windows/powershell.mdx
@@ -1,6 +1,5 @@
 ---
 title: PowerShell
-sidebar:
 ---
 
 import { Code, LinkCard } from '@astrojs/starlight/components';

--- a/src/content/docs/windows/powershell.mdx
+++ b/src/content/docs/windows/powershell.mdx
@@ -1,7 +1,6 @@
 ---
 title: PowerShell
 sidebar:
-  badge: new
 ---
 
 import { Code, LinkCard } from '@astrojs/starlight/components';


### PR DESCRIPTION
Removes the 'new' badge from the frontmatter of multiple .mdx files. The badge was present on items in the 'goodstuff', 'linux', 'website', and 'windows' sections of the documentation.

This change addresses issue #867.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Removed "new" badges from the sidebar metadata in various documentation pages. No other content or visible changes were made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->